### PR TITLE
README: say where the rows meet a chart (Vela)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,19 @@ skipped event kept in the output with its reason. No parameter fitting, no optim
 costs modeled, and disclosed amount ranges are never used as position sizes. The point is an
 honest baseline you can reproduce, not a pitch. Details: [`docs/analytics.md`](docs/analytics.md).
 
+## On a chart
+
+The rows chart well, and the hosted trackers show how: the
+[insider tracker on LuxAlgo](https://www.luxalgo.com/markets/insider-tracker) paints every Form 4
+fill onto the ticker's price tape with [Vela](https://github.com/LuxAlgo/Vela), LuxAlgo's
+open-source charting engine (`@luxalgo/vela`, Apache-2.0), as a custom renderer layer: the same
+`tracker_insider_trades` rows this repo serves, each marker still linking to its filing. That
+happens in the visitor's browser. Nothing here draws or serves a chart, and the price bars come
+from the page's own market-data source, never from LuxAlgo Market Trackers, which ships no market
+data by design. To do the same with your own store, take the rows from the MCP tools or the dumps,
+supply bars via Vela's `data` option or a provider, and paint the markers through
+[Vela's plugin SDK](https://github.com/LuxAlgo/Vela/blob/main/docs/contributing/plugin-sdk.md).
+
 ## Python
 
 The dumps are plain JSON with Parquet siblings, so nothing about LuxAlgo Market Trackers requires


### PR DESCRIPTION
## What

Adds a short **On a chart** section to the README, between *Bring your own prices* and *Python*.

The hosted [insider tracker on luxalgo.com](https://www.luxalgo.com/markets/insider-tracker) already paints Form 4 fills onto the ticker's price tape with [Vela](https://github.com/LuxAlgo/Vela) as a custom renderer layer, over the same `tracker_insider_trades` rows this repo serves. The README never mentioned it.

## Why

Vela is the open-source LuxAlgo charting engine and this is a real, shipped use of Market Trackers data on it. The paragraph also states the boundaries plainly, in line with the repo's principles: the chart is drawn in the visitor's browser, this repo draws and serves no chart or market data, and the price bars come from the page's own market-data source. It closes with how to do the same over your own store (rows from the MCP tools or the dumps, bars via Vela's `data` option or a provider, markers through Vela's plugin SDK).

## Checks

- Prettier clean (`printWidth` 100).
- Docs only, no code changes.
- Commit is DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N)_